### PR TITLE
Information theorical methods needed to import numpy

### DIFF
--- a/skfeature/function/information_theoretical_based/CMIM.py
+++ b/skfeature/function/information_theoretical_based/CMIM.py
@@ -1,6 +1,6 @@
 from skfeature.utility.entropy_estimators import *
 from skfeature.utility.util import reverse_argsort
-
+import numpy as np
 def cmim(X, y, mode="rank", **kwargs):
     """
     This function implements the CMIM feature selection.

--- a/skfeature/function/information_theoretical_based/DISR.py
+++ b/skfeature/function/information_theoretical_based/DISR.py
@@ -1,6 +1,7 @@
 from skfeature.utility.entropy_estimators import *
 from skfeature.utility.mutual_information import conditional_entropy
 from skfeature.utility.util import reverse_argsort
+import numpy as np
 
 def disr(X, y, mode="rank", **kwargs):
     """

--- a/skfeature/function/information_theoretical_based/ICAP.py
+++ b/skfeature/function/information_theoretical_based/ICAP.py
@@ -1,6 +1,6 @@
 from skfeature.utility.entropy_estimators import *
 from skfeature.utility.util import reverse_argsort
-
+import numpy as np
 def icap(X, y, mode="rank", **kwargs):
     """
     This function implements the ICAP feature selection.

--- a/skfeature/function/information_theoretical_based/JMI.py
+++ b/skfeature/function/information_theoretical_based/JMI.py
@@ -1,6 +1,6 @@
 from skfeature.function.information_theoretical_based import LCSI
 from skfeature.utility.util import reverse_argsort
-
+import numpy as np
 def jmi(X, y, mode="rank", **kwargs):
     """
     This function implements the JMI feature selection

--- a/skfeature/function/information_theoretical_based/LCSI.py
+++ b/skfeature/function/information_theoretical_based/LCSI.py
@@ -1,5 +1,5 @@
 from skfeature.utility.entropy_estimators import *
-
+import numpy as np
 
 def lcsi(X, y, **kwargs):
     """

--- a/skfeature/function/information_theoretical_based/MIFS.py
+++ b/skfeature/function/information_theoretical_based/MIFS.py
@@ -1,6 +1,6 @@
 from skfeature.function.information_theoretical_based import LCSI
 from skfeature.utility.util import reverse_argsort
-
+import numpy as np
 
 def mifs(X, y, mode="rank", **kwargs):
     """

--- a/skfeature/function/information_theoretical_based/MIM.py
+++ b/skfeature/function/information_theoretical_based/MIM.py
@@ -1,6 +1,6 @@
 from skfeature.function.information_theoretical_based import LCSI
 from skfeature.utility.util import reverse_argsort
-
+import numpy as np
 
 def mim(X, y, mode="rank", **kwargs):
     """

--- a/skfeature/function/information_theoretical_based/MRMR.py
+++ b/skfeature/function/information_theoretical_based/MRMR.py
@@ -1,6 +1,6 @@
 from skfeature.function.information_theoretical_based import LCSI
 from skfeature.utility.util import reverse_argsort
-
+import numpy as np
 def mrmr(X, y, mode="rank", **kwargs):
     """
     This function implements the MRMR feature selection


### PR DESCRIPTION
Most of the information_theorical_based functions need numpy and they didn't import, so I fixed this small bug which was making all those functions unusable.